### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["Isaac Corbrey <icorbrey@gmail.com>"]
 description = "A client library for Apache Kafka."
-homepage = "https://github.com/icorbrey/prague"
+repository = "https://github.com/icorbrey/prague"
 license = "MIT OR Apache-2.0"
 keywords = ["kafka"]
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.